### PR TITLE
Sort former deliveries by reverse delivery date

### DIFF
--- a/copanier/models.py
+++ b/copanier/models.py
@@ -509,7 +509,9 @@ class Delivery(PersistedBase):
 
     @classmethod
     def former(cls):
-        return [d for d in cls.all() if not d.is_foreseen]
+        return sorted(
+            [d for d in cls.all() if not d.is_foreseen], key=lambda d: d.from_date, reverse=True
+        )
 
     @property
     def path(self):

--- a/copanier/models.py
+++ b/copanier/models.py
@@ -503,15 +503,13 @@ class Delivery(PersistedBase):
 
     @classmethod
     def incoming(cls):
-        return sorted(
-            [d for d in cls.all() if d.is_foreseen], key=lambda d: d.order_before
-        )
+        incoming_deliveries = [d for d in cls.all() if d.is_foreseen]
+        return sorted(incoming_deliveries, key=lambda d: d.order_before)
 
     @classmethod
     def former(cls):
-        return sorted(
-            [d for d in cls.all() if not d.is_foreseen], key=lambda d: d.from_date, reverse=True
-        )
+        former_deliveries = [d for d in cls.all() if not d.is_foreseen]
+        return sorted(former_deliveries, key=lambda d: d.from_date, reverse=True)
 
     @property
     def path(self):


### PR DESCRIPTION
Starting to mess with the project with this very simple PR, improving a (very) minor UX quirk: when looking up former deliveries, we usually expect to find the most recent ones at the top of the list. This PR sorts the result of `Delivery.former()` by their `from_date` field.