### PR TITLE
Fix broken former delivery page when groups have been deleted

### DIFF
--- a/copanier/templates/includes/delivery_table.html
+++ b/copanier/templates/includes/delivery_table.html
@@ -30,7 +30,7 @@
                     <th class="amount">Total</th>
                     {% if not list_only %}
                     {% for orderer, order in delivery.orders.items() %}
-                        {% set orderer_name = request.groups.groups[orderer].name %}
+                        {% set orderer_name = request.groups.groups[orderer].name if request.groups.groups[orderer] else orderer %}
                         <th class="person">
                             {% if request.user and (request.user.is_staff or request.user.is_referent(delivery)) %}
                                 <a class="underline" href="{{ url_for('place_order', id=delivery.id) }}?orderer={{ orderer }}" title="{{ orderer }}">{{ orderer_name }} <i class="icon-pencil"></i></a>


### PR DESCRIPTION
The bug: when deleting a group, attempting to open the delivery from the "former deliveries" page fails, because it tries to read the group's name, using the id found in the `orderer` field in the group orders for this delivery. It errors out and raises the following error: `'dict object' has no attribute '<deleted group id>'`.

This PR fixes it by displaying the group's id in the table header, instead of its "human-friendly" name.

Open to feedback: should we add "(groupe supprimé)" after the group's id? Should we even show the group's id in the first place?