### PR TITLE
Add practical_info field to producers, refactor producer form

### DIFF
--- a/copanier/models.py
+++ b/copanier/models.py
@@ -210,6 +210,7 @@ class Producer(Base):
     referent_name: str = ""
     contact: str = ""
     description: str = ""
+    practical_info: str = ""
 
     def has_active_products(self, delivery):
         products = delivery.get_products_by(self.id)

--- a/copanier/static/app.css
+++ b/copanier/static/app.css
@@ -258,6 +258,13 @@ textarea {
   box-sizing: border-box;
 }
 
+textarea {
+  /* override 2rem from the previous rule to enable textareas to size themselves automatically,
+  and/or using the `rows` attribute: */
+  height: auto;
+  resize: vertical;
+}
+
 select {
   -webkit-appearance: none;
   -moz-appearance: none;

--- a/copanier/templates/products/edit_producer.html
+++ b/copanier/templates/products/edit_producer.html
@@ -34,37 +34,56 @@
 {% endif %}
 <form method="post" class="pure-form pure-form-aligned">
     <fieldset>
-    {% if producer.id %}
-    <input type="hidden" name="id" value="{{ producer.id }}">
-    {% else %}
-    <div class="pure-control-group">
-        <label for="name">Nom</label>
-        <input id="name" type="text" name="name" value="{{ producer.name or '' }}" required>
-    </div>
-    {% endif %}
-    <div class="pure-control-group">
-        <label>Description</label>
-        <input type="text" name="description" value="{{ producer.description or '' }}">
-    </div>
-    <div class="pure-control-group">
-        <label>Email référent⋅e</label>
-        <input type="email" name="referent" value="{{ producer.referent or '' }}" required>
-    </div>
-    <div class="pure-control-group">
-        <label>Nom référent⋅e</label>
-        <input type="text" name="referent_name" value="{{ producer.referent_name or '' }}" required>
-    </div>
-    <div class="pure-control-group">
-        <label>Téléphone référent⋅e</label>
-        <input pattern="((\+|00)?[0-9]{2}|0)[1-9]( ?[0-9]){8}" onInput="prettifyPhoneNumber('referent_tel')" id="referent_tel" type="tel" name="referent_tel" value="{{ producer.referent_tel or '' }}" required>
-    </div>
-    <div class="pure-control-group">
-        <label>Contact producteur⋅rice</label>
-        <input type="text" name="contact" value="{{ producer.contact or '' }}">
-    </div>
-    <div class="pure-controls">
-        <input type="submit" name="submit" value="Valider" class="primary">
-    </div>
+        {% if producer.id %}
+            <input type="hidden" name="id" value="{{ producer.id }}">
+        {% else %}
+            <div class="pure-control-group">
+                <label for="producer_name">Nom</label>
+                <input id="producer_name" type="text" name="name" value="{{ producer.name or '' }}" required>
+            </div>
+        {% endif %}
+
+        <div class="pure-control-group">
+            <label for="producer_description" class="pure-input-1-3">Description</label>
+            <input class="pure-input-2-3" type="text" id="producer_description" name="description" value="{{ producer.description or '' }}">
+        </div>
+        <div class="pure-control-group">
+            <label for="producer_referent" class="pure-input-1-3">Email référent⋅e</label>
+            <input class="pure-input-2-3" type="email" id="producer_referent" name="referent" value="{{ producer.referent or '' }}" required>
+        </div>
+        <div class="pure-control-group">
+            <label for="producer_referent_name" class="pure-input-1-3">Nom référent⋅e</label>
+            <input class="pure-input-2-3" type="text" id="producer_referent_name" name="referent_name" value="{{ producer.referent_name or '' }}" required>
+        </div>
+        <div class="pure-control-group">
+            <label for="producer_referent_tel" class="pure-input-1-3">Téléphone référent⋅e</label>
+            <input class="pure-input-2-3"
+                type="tel"
+                id="producer_referent_tel"
+                name="referent_tel"
+                pattern="((\+|00)?[0-9]{2}|0)[1-9]( ?[0-9]){8}"
+                onInput="prettifyPhoneNumber('referent_tel')"
+                value="{{ producer.referent_tel or '' }}"
+                required
+            />
+        </div>
+        <div class="pure-control-group">
+            <label for="producer_contact" class="pure-input-1-3">Contact producteur⋅rice</label>
+            <input class="pure-input-2-3" type="text" id="producer_contact" name="contact" value="{{ producer.contact or '' }}">
+        </div>
+        <div class="pure-control-group">
+            <label for="producer_practical_info" class="pure-input-1-1">Infos pratiques</label>
+            <textarea
+                class="pure-input-2-3"
+                id="producer_practical_info"
+                name="practical_info"
+                rows="10"
+                placeholder="Infos pour le/la référent⋅e : moyen de contact à privilégier, comment les produits sont-ils habituellement livrés..."
+            >{{ producer.practical_info or '' }}</textarea>
+        </div>
+        <div class="pure-controls">
+            <input type="submit" name="submit" value="Valider" class="primary">
+        </div>
     </fieldset>
 </form>
 

--- a/copanier/views/products.py
+++ b/copanier/views/products.py
@@ -70,6 +70,7 @@ async def edit_producer(request, response, delivery_id, producer_id):
         producer.referent_name = form.get("referent_name")
         producer.description = form.get("description")
         producer.contact = form.get("contact")
+        producer.practical_info = form.get("practical_info")
         delivery.producers[producer_id] = producer
         delivery.persist()
 


### PR DESCRIPTION
* Add the `practical_info` field to the producer model & form
  * Full-text field, using a `textarea` field to enable referents to add some details about how to communicate with this producer, how to get the up-to-date prices, how to order & pick up the order, how to pay... in the hope to make the referent handover process a bit smoother thanks to the relevant info being written down

* Minor refactors to producer form:
  * Fix indentation
  * Add `for` and `id` attributes to all labels & fields to enable clicking the label to select the associated fields (ids are scoped with `producer_{field_name}` to reduce the likelihood of an id collision with another template
  * Make the form fields 100% width


Before:

<img width="781" alt="image" src="https://github.com/almet/copanier/assets/14823737/1e5264f9-0f57-4f82-ae3c-8c1d16eb11e8">

After:

<img width="979" alt="image" src="https://github.com/almet/copanier/assets/14823737/23a87712-0f4a-4725-9a2d-6c0e7534c18e">
